### PR TITLE
fix: adding ifndef/define NO_IOLOOP in cti-proto.h to mimic behaviour…

### DIFF
--- a/ServiceRegistration/cti-proto.h
+++ b/ServiceRegistration/cti-proto.h
@@ -24,6 +24,10 @@
 #include <stdbool.h>
 #include "cti-common.h"
 
+#ifndef NO_IOLOOP
+#define NO_IOLOOP 1
+#endif
+
 typedef struct cti_buffer cti_buffer_t;
 struct cti_buffer {
 	size_t expected;

--- a/ServiceRegistration/cti-proto.h
+++ b/ServiceRegistration/cti-proto.h
@@ -24,10 +24,6 @@
 #include <stdbool.h>
 #include "cti-common.h"
 
-#ifndef NO_IOLOOP
-#define NO_IOLOOP 1
-#endif
-
 typedef struct cti_buffer cti_buffer_t;
 struct cti_buffer {
 	size_t expected;

--- a/ServiceRegistration/cti-server.h
+++ b/ServiceRegistration/cti-server.h
@@ -28,10 +28,6 @@
 #define CTI_EVENT_PARTITION_ID (1 << 4)
 #define CTI_EVENT_STATE        (1 << 5)
 
-#ifndef NO_IOLOOP
-#define NO_IOLOOP 1
-#endif
-
 #ifndef NOT_HAVE_SA_LEN
 #define NOT_HAVE_SA_LEN 1
 #endif


### PR DESCRIPTION
… on cti-server.h

While building for a different target we found out `cti_connection_t` structure was being interpreted as different structures by two different compilation units