### PR TITLE
fix registering preferred address

### DIFF
--- a/ServiceRegistration/srp-client.c
+++ b/ServiceRegistration/srp-client.c
@@ -1166,7 +1166,7 @@ generate_srp_update(client_state_t *client, uint32_t update_lease_time, uint32_t
         for (addr = interfaces; addr; addr = addr->next) {
             // If we have an IPv6 address that's on the same prefix as the server's address, send only that
             // IPv6 address.
-            if (addr->rr.type != dns_rrtype_aaaa ||
+            if (addr->rr.type == dns_rrtype_aaaa &&
                 (addr->rr.type == server->rr.type && !memcmp(&addr->rr.data, &server->rr.data, 8)))
             {
                 have_good_address = true;
@@ -1185,6 +1185,10 @@ generate_srp_update(client_state_t *client, uint32_t update_lease_time, uint32_t
             if (have_good_address) {
                 break;
             }
+        }
+
+        if (have_good_address) {
+            break;
         }
     }
 


### PR DESCRIPTION
## The problem
We get an IPv4 address when browsing the mDNS service which is registered by a Thread device (controlled via `ot-daemon`).
```txt
srp-api-test._ipps._tcp.local.
192.168.43.239
```
This IPv4 address belongs to `wlan0` but not `wpan0`.

## Expected behavior
The mDNS service should contain the off-mesh reachable IPv6 address of the Thread device.

## Fix
This PR fixes this issue by advertising only the off-mesh-reachable IPv6 address if it is present. The comment indicates the expected behavior:
https://github.com/Abhayakara/mdnsresponder/blob/eb98f19aff6cfd431414fd55fa6a97136abeb381/ServiceRegistration/srp-client.c#L1167-L1169