### PR TITLE
[srp-client] support specifying interface

### DIFF
--- a/ServiceRegistration/dnssd-proxy.c
+++ b/ServiceRegistration/dnssd-proxy.c
@@ -2076,7 +2076,7 @@ main(int argc, char **argv)
         return 1;
     }
 
-    ioloop_map_interface_addresses(&served_domains, ifaddr_callback);
+    ioloop_map_interface_addresses(NULL, &served_domains, ifaddr_callback);
 
     // Set up hardwired answers
     dnssd_hardwired_setup();

--- a/ServiceRegistration/ioloop.h
+++ b/ServiceRegistration/ioloop.h
@@ -251,7 +251,7 @@ void ioloop_message_release_(message_t *NONNULL message, const char *NONNULL fil
 bool ioloop_send_multicast(comm_t *NONNULL comm, int ifindex, struct iovec *NONNULL iov, int iov_len);
 bool ioloop_send_message(comm_t *NONNULL connection, message_t *NULLABLE responding_to,
                          struct iovec *NONNULL iov, int iov_len);
-bool ioloop_map_interface_addresses(void *NULLABLE context, interface_callback_t NONNULL callback);
+bool ioloop_map_interface_addresses(const char *NULLABLE interface, void *NULLABLE context, interface_callback_t NONNULL callback);
 ssize_t ioloop_recvmsg(int sock, uint8_t *NONNULL buffer, size_t buffer_length, int *NONNULL ifindex,
                        int *NONNULL hoplimit, addr_t *NONNULL source, addr_t *NONNULL destination);
 #define ioloop_subproc_release(subproc) ioloop_subproc_release_(subproc, __FILE__, __LINE__)

--- a/ServiceRegistration/posix.c
+++ b/ServiceRegistration/posix.c
@@ -48,7 +48,7 @@ struct interface_addr {
 interface_addr_t *interface_addresses;
 
 bool
-ioloop_map_interface_addresses(void *context, interface_callback_t callback)
+ioloop_map_interface_addresses(const char *interface, void *context, interface_callback_t callback)
 {
     struct ifaddrs *ifaddrs, *ifp;
     interface_addr_t *kept_ifaddrs = NULL, **ki_end = &kept_ifaddrs;
@@ -63,6 +63,10 @@ ioloop_map_interface_addresses(void *context, interface_callback_t callback)
     for (ifp = ifaddrs; ifp; ifp = ifp->ifa_next) {
         bool remove = false;
         bool keep = true;
+
+        if (interface != NULL && ifp->ifa_name != NULL && strcmp(interface, ifp->ifa_name)) {
+            continue;
+        }
 
 #ifndef LINUX
         // Check for temporary addresses, etc.

--- a/ServiceRegistration/route.c
+++ b/ServiceRegistration/route.c
@@ -2488,7 +2488,7 @@ refresh_interface_list(void)
 {
     interface_t *interface;
     bool have_active = false;
-    ioloop_map_interface_addresses(NULL, ifaddr_callback);
+    ioloop_map_interface_addresses(NULL, NULL, ifaddr_callback);
     for (interface = interfaces; interface; interface = interface->next) {
         if (!interface->ineligible && !interface->inactive) {
             have_active = true;

--- a/ServiceRegistration/srp-ioloop.c
+++ b/ServiceRegistration/srp-ioloop.c
@@ -46,6 +46,8 @@ const uint64_t thread_enterprise_number = 52627;
 
 cti_connection_t thread_service_context;
 
+static const char *interface = NULL;
+
 #define SRP_IO_CONTEXT_MAGIC 0xFEEDFACEFADEBEEFULL  // BEES!   Everybody gets BEES!
 typedef struct io_context {
     uint64_t magic_cookie1;
@@ -404,7 +406,7 @@ static void
 usage(void)
 {
     fprintf(stderr,
-            "srp-client [--lease-time <seconds>] [--client-count <client count>] [--server <address>%%<port>]\n"
+            "srp-client [--lease-time <seconds>] [--client-count <client count>] [--interface <interface name>] [--server <address>%%<port>]\n"
             "           [--random-leases] [--delete-registrations] [--use-thread-services] [--log-stderr]\n"
             "           [--bogusify-signatures]\n");
     exit(1);
@@ -422,7 +424,7 @@ cti_service_list_callback(void *UNUSED context, cti_service_vec_t *services, cti
     }
 
     srp_start_address_refresh();
-    ioloop_map_interface_addresses(services, interface_callback);
+    ioloop_map_interface_addresses(interface, services, interface_callback);
     for (i = 0; i < services->num; i++) {
         cti_service_t *cti_service = services->services[i];
         // Look for SRP service advertisements only.
@@ -469,6 +471,9 @@ main(int argc, char **argv)
         } else if (!strcmp(argv[i], "--client-count")) {
             nump = &num_clients;
             goto number;
+        } else if (!strcmp(argv[i], "--interface")) {
+            interface = argv[i+1];
+            i++;
         } else if (!strcmp(argv[i], "--server")) {
             char *percent;
             int server_port;
@@ -522,7 +527,7 @@ main(int argc, char **argv)
     }
 
     if (!use_thread_services) {
-        ioloop_map_interface_addresses(NULL, interface_callback);
+        ioloop_map_interface_addresses(interface, NULL, interface_callback);
     }
 
     if (!have_server_address && !use_thread_services) {


### PR DESCRIPTION
This PR adds an option `--interface` which specifies the interface to use for the SRP client.

This is useful for:
1. testing the server's behavior on IP addresses handling.
2. testing with Thread devices which are IPv6-only.