### PR TITLE
Ignore -Wdate-time warning when generating version string

### DIFF
--- a/Clients/dns-sd.c
+++ b/Clients/dns-sd.c
@@ -2267,7 +2267,10 @@ Fail:
 
 // NOT static -- otherwise the compiler may optimize it out
 // The "@(#) " pattern is a special prefix the "what" command looks for
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdate-time"
 const char VersionString_SCCS[] = "@(#) dns-sd " STRINGIFY(mDNSResponderVersion) " (" __DATE__ " " __TIME__ ")";
+#pragma GCC diagnostic pop
 
 #if _BUILDING_XCODE_PROJECT_
 // If the process crashes, then this string will be magically included in the automatically-generated crash log


### PR DESCRIPTION
In this commit I followed the fix from `dnssd_clientlib.c`. However, the warning sound reasonable (it makes reproducible builds possible, which is a part of chain of trust and important security measure), so I would advise for removing `__DATE__` and `__TIME__` macros from the version string. Please let me know and I will update this commit if you agree.

I also found a bunch of other uses of this macro in several other files, so it would be worthy to fix them too. However, I didn't get to building them for my OS, so I couldn't verify the source changes myself.