### PR TITLE
Fix build on systems without TCP_NOTSENT_LOWAT.

### DIFF
--- a/mDNSShared/PlatformCommon.c
+++ b/mDNSShared/PlatformCommon.c
@@ -380,12 +380,14 @@ mDNSexport mDNSBool mDNSPosixTCPSocketSetup(int *fd, mDNSAddr_Type addrType, mDN
     if (port)
         port->NotAnInteger = outTcpPort->NotAnInteger;
 
+#ifdef TCP_NOTSENT_LOWAT
     err = setsockopt(sock, IPPROTO_TCP, TCP_NOTSENT_LOWAT, &lowWater, sizeof lowWater);
     if (err < 0)
     {
         LogRedact(MDNS_LOG_CATEGORY_DEFAULT, MDNS_LOG_DEFAULT, "mDNSPosixTCPSocketSetup: TCP_NOTSENT_LOWAT failed: " PUB_S, strerror(errno));
         return mDNSfalse;
     }
+#endif
 
     return mDNStrue;
 }
@@ -430,6 +432,7 @@ mDNSexport TCPSocket *mDNSPosixDoTCPListenCallback(int fd, mDNSAddr_Type address
         goto out;
     }
 
+#ifdef TCP_NOTSENT_LOWAT
     failed = setsockopt(remoteSock, IPPROTO_TCP, TCP_NOTSENT_LOWAT,
                         &lowWater, sizeof lowWater);
     if (failed < 0)
@@ -438,6 +441,7 @@ mDNSexport TCPSocket *mDNSPosixDoTCPListenCallback(int fd, mDNSAddr_Type address
         LogMsg("mDNSPosixDoTCPListenCallback: TCP_NOTSENT_LOWAT returned %d", errno);
         goto out;
     }
+#endif
 
     if (address.sa.sa_family == AF_INET6)
     {


### PR DESCRIPTION
This option is not available on kernels older than 3.12 and may still
not be available on some newer.