### PR TITLE
Fix dnssd build on non-Windows targets using TCP loopback.

### DIFF
--- a/mDNSShared/dnssd_ipc.h
+++ b/mDNSShared/dnssd_ipc.h
@@ -75,9 +75,7 @@ extern char *win32_strerror(int inErrorCode);
 #if defined(USE_TCP_LOOPBACK)
 #   define AF_DNSSD             AF_INET
 #   define MDNS_TCP_SERVERADDR  "127.0.0.1"
-#ifdef WIN32_CENTENNIAL
 #   define MDNS_TCP_SERVERPORT_CENTENNIAL  53545
-#endif
 #   define MDNS_TCP_SERVERPORT  5354
 #   define LISTENQ              5
 #   define dnssd_sockaddr_t     struct sockaddr_in


### PR DESCRIPTION
`dnssd_clientstub.c` fails to build because MDNS_TCP_SERVERPORT_CENTENNIAL is not defined on line 649:

```
#if defined(USE_TCP_LOOPBACK)
...
saddr.sin_port        = IsSystemServiceDisabled() ? htons(MDNS_TCP_SERVERPORT_CENTENNIAL) : htons(MDNS_TCP_SERVERPORT);
#else
...
#endif         
```