### PR TITLE
Flush pending deregistrations prior to stopping

### DIFF
--- a/mDNSCore/mDNS.c
+++ b/mDNSCore/mDNS.c
@@ -15338,6 +15338,9 @@ mDNSexport void mDNS_StartExit(mDNS *const m)
             rr->resrec.RecordType, ARDisplayString(m, rr));
     }
 
+    // Send responses to flush any pending deregistrations
+    SendResponses(m);
+
     // If any deregistering records remain, send their deregistration announcements before we exit
     if (m->mDNSPlatformStatus != mStatus_NoError) DiscardDeregistrations(m);
 


### PR DESCRIPTION
[Original change](https://cs.android.com/android/_/android/platform/external/mdnsresponder/+/56c1ef634312c39f2831e92102c465ebf1b0399e) on AOSP