### PR TITLE
Don't enable mDNS on non-multicast, non-broadcast interfaces.

### DIFF
--- a/mDNSPosix/mDNSPosix.c
+++ b/mDNSPosix/mDNSPosix.c
@@ -1487,7 +1487,7 @@ mDNSlocal int SetupInterfaceList(mDNS *const m)
                         firstLoopbackIndex = ifIndex;
                     }
                 }
-                else
+                else if (i->ifa_flags & (IFF_MULTICAST | IFF_BROADCAST))
                 {
                     const int ethernet_addr_len = 6;
                     uint8_t hwaddr[ethernet_addr_len];


### PR DESCRIPTION
[Original change](https://r.android.com/181894) on AOSP.