### PR TITLE
Don't daemonize on Android

### DIFF
--- a/mDNSPosix/PosixDaemon.c
+++ b/mDNSPosix/PosixDaemon.c
@@ -109,8 +109,10 @@ mDNSlocal void ParseCmdLineArgs(int argc, char **argv)
     }
     if (!mDNS_DebugMode)
     {
+#ifndef __ANDROID__
         int result = daemon(0, 0);
         if (result != 0) { LogMsg("Could not run as daemon - exiting"); exit(result); }
+#endif
 #if __APPLE__
         LogMsg("The POSIX mdnsd should only be used on OS X for testing - exiting");
         exit(-1);


### PR DESCRIPTION
Android has it's own init system which handles foreground processes as daemons. Forking daemon out and exitting would give it hard time tracking it.

Side comment: please take a look at the `__APPLE__` check below the ifndef I added. By the time your main process gets to this `exit(-1)` on your OS, daemon would be already forked out. You might want to fix this (probably by putting the apple block before `daemon()` call).